### PR TITLE
fix: Fix entities detection in JS logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -704,8 +704,8 @@ function extractId(key) {
 function findEntityContainer(data) {
   if (data && typeof data === 'object' && !Array.isArray(data)) {
     const keys = Object.keys(data);
-    if (keys.length > 100 && keys.some(k => /^\(ID=\d+\)$/.test(k))) {
-      return data;
+    if (Object.hasOwn(data, 'entities') && typeof data.entities === 'object') {
+      return data.entities;
     }
     for (const v of Object.values(data)) {
       const r = findEntityContainer(v);


### PR DESCRIPTION
Change from any array that has `ID` elements that is over 100 entries to only return when the data has an 'entities' property.

(close Wilhelm-af#14)